### PR TITLE
Selection nodes to have individual mode selection

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -65,6 +65,8 @@ def convert_data(data, from_type=None, to_type=None):
                 val = bpy.data.objects.find(data.name)
             elif (from_type == "ARRAY"):
                 val = len(eval(data))
+            elif (from_type == "SELECTION_TYPE"):
+                return False, None
         elif (to_type == "BOOL"):
             if (from_type == "NUMBER"):
                 val = bool(data)
@@ -78,6 +80,8 @@ def convert_data(data, from_type=None, to_type=None):
                 val = bool(data)
             elif (from_type == "ARRAY"):
                 val = bool(eval(data))
+            elif (from_type == "SELECTION_TYPE"):
+                val = data[0] or data[1] or data[2]
         elif (to_type == "STRING"):
             if (from_type == "NUMBER"):
                 val = str(data)
@@ -91,6 +95,8 @@ def convert_data(data, from_type=None, to_type=None):
                 val = str(repr(data))
             elif (from_type == "ARRAY"):
                 val = data
+            elif (from_type == "SELECTION_TYPE"):
+                val = selection_type_to_string(data)
         elif (to_type == "VECTOR"):
             if (from_type == "NUMBER"):
                 val = (data, data, data)
@@ -104,6 +110,8 @@ def convert_data(data, from_type=None, to_type=None):
                 return False, None
             elif (from_type == "ARRAY"):
                 val = Vector((eval(data)[0], eval(data)[1], eval(data)[2])).to_tuple()
+            elif (from_type == "SELECTION_TYPE"):
+                val = Vector((float(eval(data)[0]), float(eval(data)[1]), float(eval(data)[2]))).to_tuple()
         elif (to_type == "OBJECT"):
             if (from_type == "NUMBER"):
                 val = bpy.data.objects[data]
@@ -130,6 +138,36 @@ def convert_data(data, from_type=None, to_type=None):
                 val = "[" + repr(data) + "]"
             elif (from_type == "ARRAY"):
                 val = data
+            elif (from_type == "SELECTION_TYPE"):
+                val = data
+        elif (to_type == "SELECTION_TYPE"): # TODO: Add more automatic conversions
+            if (from_type == "NUMBER"):
+                return False, None
+            elif (from_type == "BOOL"):
+                return False, None
+            elif (from_type == "STRING"):
+                return False, None
+            elif (from_type == "VECTOR"):
+                val = [bool(data[0]), bool(data[1]), bool(data[2])]
+            elif (from_type == "OBJECT"):
+                return False, None
+            elif (from_type == "ARRAY"):
+                val = [bool(eval(data)[0]), bool(eval(data)[1]), bool(eval(data)[2])]
+            elif (from_type == "SELECTION_TYPE"):
+                val = data
         return True, val
     except:
         return False, None
+
+def selection_type_to_string(sel_type):
+    out = []
+    if sel_type[0]:
+        out.append("Vertex")
+
+    if sel_type[1]:
+        out.append("Edge")
+
+    if sel_type[2]:
+        out.append("Face")
+
+    return " + ".join(out)

--- a/helper.py
+++ b/helper.py
@@ -161,13 +161,13 @@ def convert_data(data, from_type=None, to_type=None):
 
 def selection_type_to_string(sel_type):
     out = []
-    if sel_type[0]:
+    if "VERT" in sel_type:
         out.append("Vertex")
 
-    if sel_type[1]:
+    if "EDGE" in sel_type:
         out.append("Edge")
 
-    if sel_type[2]:
+    if "FACE" in sel_type:
         out.append("Face")
 
     return " + ".join(out)

--- a/helper.py
+++ b/helper.py
@@ -81,7 +81,7 @@ def convert_data(data, from_type=None, to_type=None):
             elif (from_type == "ARRAY"):
                 val = bool(eval(data))
             elif (from_type == "SELECTION_TYPE"):
-                val = data[0] or data[1] or data[2]
+                val = len(data) != 0
         elif (to_type == "STRING"):
             if (from_type == "NUMBER"):
                 val = str(data)
@@ -96,7 +96,7 @@ def convert_data(data, from_type=None, to_type=None):
             elif (from_type == "ARRAY"):
                 val = data
             elif (from_type == "SELECTION_TYPE"):
-                val = selection_type_to_string(data)
+                val = str(data)
         elif (to_type == "VECTOR"):
             if (from_type == "NUMBER"):
                 val = (data, data, data)
@@ -111,7 +111,7 @@ def convert_data(data, from_type=None, to_type=None):
             elif (from_type == "ARRAY"):
                 val = Vector((eval(data)[0], eval(data)[1], eval(data)[2])).to_tuple()
             elif (from_type == "SELECTION_TYPE"):
-                val = Vector((float(eval(data)[0]), float(eval(data)[1]), float(eval(data)[2]))).to_tuple()
+                val = Vector(float("VERT" in data), float("EDGE" in data), float("FACE" in data)).to_tuple()
         elif (to_type == "OBJECT"):
             if (from_type == "NUMBER"):
                 val = bpy.data.objects[data]
@@ -124,6 +124,8 @@ def convert_data(data, from_type=None, to_type=None):
             elif (from_type == "OBJECT"):
                 val = data
             elif (from_type == "ARRAY"):
+                return False, None
+            elif (from_type == "SELECTION_TYPE"):
                 return False, None
         elif (to_type == "ARRAY"):
             if (from_type == "NUMBER"):
@@ -139,20 +141,33 @@ def convert_data(data, from_type=None, to_type=None):
             elif (from_type == "ARRAY"):
                 val = data
             elif (from_type == "SELECTION_TYPE"):
-                val = data
-        elif (to_type == "SELECTION_TYPE"): # TODO: Add more automatic conversions
+                val = str(list(data))
+        elif (to_type == "SELECTION_TYPE"):
             if (from_type == "NUMBER"):
                 return False, None
             elif (from_type == "BOOL"):
                 return False, None
             elif (from_type == "STRING"):
-                return False, None
+                val = eval(data)
             elif (from_type == "VECTOR"):
-                val = [bool(data[0]), bool(data[1]), bool(data[2])]
+                val = set()
+                if bool(data[0]):
+                    val.add("VERT")
+                if bool(data[1]):
+                    val.add("EDGE")
+                if bool(data[2]):
+                    val.add("FACE")
             elif (from_type == "OBJECT"):
                 return False, None
-            elif (from_type == "ARRAY"):
-                val = [bool(eval(data)[0]), bool(eval(data)[1]), bool(eval(data)[2])]
+            elif (from_type == "ARRAY"): # Allows you to take in a boolean array
+                data_eval = eval(data)
+                val = set()
+                if bool(data_eval[0]):
+                    val.add("VERT")
+                if bool(data_eval[1]):
+                    val.add("EDGE")
+                if bool(data_eval[2]):
+                    val.add("FACE")
             elif (from_type == "SELECTION_TYPE"):
                 val = data
         return True, val

--- a/nodes/_base/node_selection.py
+++ b/nodes/_base/node_selection.py
@@ -15,7 +15,7 @@ class ScSelectionNode(ScNode):
         return (
             self.inputs["Object"].default_value == None
         )
-    
+
     def pre_execute(self):
         focus_on_object(self.inputs["Object"].default_value, True)
     

--- a/nodes/_base/node_selection.py
+++ b/nodes/_base/node_selection.py
@@ -1,14 +1,19 @@
 import bpy
 
+from bpy.props import EnumProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from ...helper import focus_on_object
 
 class ScSelectionNode(ScNode):
+
+    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={}, options={"ENUM_FLAG"}, update=ScNode.update_value)
+
     def init(self, context):
         self.node_executable = True
         super().init(context)
         self.inputs.new("ScNodeSocketObject", "Object")
+        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.outputs.new("ScNodeSocketObject", "Object")
     
     def error_condition(self):
@@ -17,6 +22,9 @@ class ScSelectionNode(ScNode):
         )
 
     def pre_execute(self):
+        if "Selection Type" in self.inputs:
+            bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
+            pass
         focus_on_object(self.inputs["Object"].default_value, True)
     
     def post_execute(self):

--- a/nodes/_base/node_selection.py
+++ b/nodes/_base/node_selection.py
@@ -7,13 +7,13 @@ from ...helper import focus_on_object
 
 class ScSelectionNode(ScNode):
 
-    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={}, options={"ENUM_FLAG"}, update=ScNode.update_value)
+    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default=set(), options={"ENUM_FLAG"}, update=ScNode.update_value)
 
     def init(self, context):
         self.node_executable = True
         super().init(context)
         self.inputs.new("ScNodeSocketObject", "Object")
-        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
+        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type")
         self.outputs.new("ScNodeSocketObject", "Object")
     
     def error_condition(self):
@@ -22,7 +22,7 @@ class ScSelectionNode(ScNode):
         )
 
     def pre_execute(self):
-        if "Selection Type" in self.inputs:
+        if len(self.inputs["Selection Type"].default_value) != 0:
             bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
             pass
         focus_on_object(self.inputs["Object"].default_value, True)

--- a/nodes/constants/ScSelectionType.py
+++ b/nodes/constants/ScSelectionType.py
@@ -9,7 +9,7 @@ class ScSelectionType(Node, ScNode):
     bl_idname = "ScSelectionType"
     bl_label = "Selection Type"
 
-    prop_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
+    prop_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
     def init(self, context):
         super().init(context)
         self.outputs.new("ScNodeSocketSelectionType", "Value")
@@ -17,11 +17,6 @@ class ScSelectionType(Node, ScNode):
     def draw_buttons(self, context, layout):
         super().draw_buttons(context, layout)
         layout.column().prop(self, "prop_type")
-        # row = layout.row(align = True)
-        # row.prop(self, "prop_type", index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
-        # row.prop(self, "prop_type", index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
-        # row.prop(self, "prop_type", index = 2, toggle = True, icon_only = True, icon = "FACESEL")
-        # row.alignment = "CENTER"
     
     def post_execute(self):
         return {"Value": self.prop_type}

--- a/nodes/constants/ScSelectionType.py
+++ b/nodes/constants/ScSelectionType.py
@@ -1,7 +1,7 @@
 import bpy
 import mathutils
 
-from bpy.props import BoolVectorProperty
+from bpy.props import BoolVectorProperty, EnumProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 
@@ -9,19 +9,19 @@ class ScSelectionType(Node, ScNode):
     bl_idname = "ScSelectionType"
     bl_label = "Selection Type"
 
-    prop_type: BoolVectorProperty(default=(True, False, False), update=ScNode.update_value)
-
+    prop_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
     def init(self, context):
         super().init(context)
         self.outputs.new("ScNodeSocketSelectionType", "Value")
     
     def draw_buttons(self, context, layout):
         super().draw_buttons(context, layout)
-        row = layout.row(align = True)
-        row.prop(self, "prop_type", index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
-        row.prop(self, "prop_type", index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
-        row.prop(self, "prop_type", index = 2, toggle = True, icon_only = True, icon = "FACESEL")
-        row.alignment = "CENTER"
+        layout.column().prop(self, "prop_type")
+        # row = layout.row(align = True)
+        # row.prop(self, "prop_type", index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
+        # row.prop(self, "prop_type", index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
+        # row.prop(self, "prop_type", index = 2, toggle = True, icon_only = True, icon = "FACESEL")
+        # row.alignment = "CENTER"
     
     def post_execute(self):
         return {"Value": self.prop_type}

--- a/nodes/constants/ScSelectionType.py
+++ b/nodes/constants/ScSelectionType.py
@@ -1,0 +1,27 @@
+import bpy
+import mathutils
+
+from bpy.props import BoolVectorProperty
+from bpy.types import Node
+from .._base.node_base import ScNode
+
+class ScSelectionType(Node, ScNode):
+    bl_idname = "ScSelectionType"
+    bl_label = "Selection Type"
+
+    prop_type: BoolVectorProperty(default=(True, False, False), update=ScNode.update_value)
+
+    def init(self, context):
+        super().init(context)
+        self.outputs.new("ScNodeSocketSelectionType", "Value")
+    
+    def draw_buttons(self, context, layout):
+        super().draw_buttons(context, layout)
+        row = layout.row(align = True)
+        row.prop(self, "prop_type", index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
+        row.prop(self, "prop_type", index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
+        row.prop(self, "prop_type", index = 2, toggle = True, icon_only = True, icon = "FACESEL")
+        row.alignment = "CENTER"
+    
+    def post_execute(self):
+        return {"Value": self.prop_type}

--- a/nodes/selection/ScSelectByIndex.py
+++ b/nodes/selection/ScSelectByIndex.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import EnumProperty, IntProperty, BoolProperty
+from bpy.props import IntProperty, BoolProperty, BoolVectorProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_selection import ScSelectionNode
@@ -9,7 +9,7 @@ class ScSelectByIndex(Node, ScSelectionNode):
     bl_idname = "ScSelectByIndex"
     bl_label = "Select by Index"
     
-    in_selection_type: EnumProperty(items=[("FACE", "Face", ""), ("VERT", "Vertex", ""), ("EDGE", "Edge", "")], default="FACE", update=ScNode.update_value)
+    in_selection_type: BoolVectorProperty(default=(True, False, False), update=ScNode.update_value)
     in_index: IntProperty(min=0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
@@ -29,12 +29,16 @@ class ScSelectByIndex(Node, ScSelectionNode):
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
         data = []
-        if (bpy.context.tool_settings.mesh_select_mode[0]):
+        
+        bpy.context.tool_settings.mesh_select_mode = self.inputs["Selection Type"].default_value
+
+        if (self.inputs["Selection Type"].default_value[0]):
             data.append(self.inputs["Object"].default_value.data.vertices)
-        if (bpy.context.tool_settings.mesh_select_mode[1]):
+        if (self.inputs["Selection Type"].default_value[1]):
             data.append(self.inputs["Object"].default_value.data.edges)
-        if (bpy.context.tool_settings.mesh_select_mode[2]):
+        if (self.inputs["Selection Type"].default_value[2]):
             data.append(self.inputs["Object"].default_value.data.polygons)
+
         if (not (self.inputs["Deselect"].default_value or self.inputs["Extend"].default_value)):
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_all(action="DESELECT")

--- a/nodes/selection/ScSelectByIndex.py
+++ b/nodes/selection/ScSelectByIndex.py
@@ -13,11 +13,9 @@ class ScSelectByIndex(Node, ScSelectionNode):
     in_index: IntProperty(min=0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
     
     def init(self, context):
         super().init(context)
-        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.inputs.new("ScNodeSocketNumber", "Index").init("in_index", True)
         self.inputs.new("ScNodeSocketBool", "Extend").init("in_extend")
         self.inputs.new("ScNodeSocketBool", "Deselect").init("in_deselect")
@@ -31,8 +29,6 @@ class ScSelectByIndex(Node, ScSelectionNode):
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
         data = []
-
-        bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
 
         if (bpy.context.tool_settings.mesh_select_mode[0]):
             data.append(self.inputs["Object"].default_value.data.vertices)

--- a/nodes/selection/ScSelectByIndex.py
+++ b/nodes/selection/ScSelectByIndex.py
@@ -9,7 +9,6 @@ class ScSelectByIndex(Node, ScSelectionNode):
     bl_idname = "ScSelectByIndex"
     bl_label = "Select by Index"
     
-    in_selection_type: EnumProperty(items=[("FACE", "Face", ""), ("VERT", "Vertex", ""), ("EDGE", "Edge", "")], default="FACE", update=ScNode.update_value)
     in_index: IntProperty(min=0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)

--- a/nodes/selection/ScSelectByLocation.py
+++ b/nodes/selection/ScSelectByLocation.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import BoolVectorProperty, BoolProperty, FloatVectorProperty, BoolProperty, EnumProperty
+from bpy.props import BoolProperty, FloatVectorProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_selection import ScSelectionNode

--- a/nodes/selection/ScSelectByLocation.py
+++ b/nodes/selection/ScSelectByLocation.py
@@ -13,12 +13,9 @@ class ScSelectByLocation(Node, ScSelectionNode):
     in_max: FloatVectorProperty(default=(1.0, 1.0, 1.0), update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
 
     def init(self, context):
         super().init(context)
-
-        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.inputs.new("ScNodeSocketVector", "Minimum").init("in_min", True)
         self.inputs.new("ScNodeSocketVector", "Maximum").init("in_max", True)
         self.inputs.new("ScNodeSocketBool", "Extend").init("in_extend")
@@ -26,8 +23,6 @@ class ScSelectByLocation(Node, ScSelectionNode):
 
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
-
-        bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
 
         if (not (self.inputs["Deselect"].default_value or self.inputs["Extend"].default_value)):
             bpy.ops.object.mode_set(mode="EDIT")

--- a/nodes/selection/ScSelectByLocation.py
+++ b/nodes/selection/ScSelectByLocation.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty
+from bpy.props import BoolVectorProperty, BoolProperty, FloatVectorProperty, BoolProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_selection import ScSelectionNode
@@ -13,31 +13,42 @@ class ScSelectByLocation(Node, ScSelectionNode):
     in_max: FloatVectorProperty(default=(1.0, 1.0, 1.0), update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    
+    in_selection_type: BoolVectorProperty(default=(True, False, False), update=ScNode.update_value)
+
+    # items=[("FACE", "Face", ""), ("EDGE", "Edge", ""), ("VERTEX", "Vertex", "")]
     def init(self, context):
         super().init(context)
+
+        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.inputs.new("ScNodeSocketVector", "Minimum").init("in_min", True)
         self.inputs.new("ScNodeSocketVector", "Maximum").init("in_max", True)
         self.inputs.new("ScNodeSocketBool", "Extend").init("in_extend")
         self.inputs.new("ScNodeSocketBool", "Deselect").init("in_deselect")
-    
+
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
+
+        bpy.context.tool_settings.mesh_select_mode = self.inputs["Selection Type"].default_value
+
         if (not (self.inputs["Deselect"].default_value or self.inputs["Extend"].default_value)):
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_all(action="DESELECT")
             bpy.ops.object.mode_set(mode="OBJECT")
-        if (bpy.context.tool_settings.mesh_select_mode[0]):
+
+        if (self.inputs["Selection Type"].default_value[0]):
             for vertex in self.inputs["Object"].default_value.data.vertices:
                 if (((vertex.co[0]>=self.inputs["Minimum"].default_value[0] and vertex.co[1]>=self.inputs["Minimum"].default_value[1] and vertex.co[2]>=self.inputs["Minimum"].default_value[2]) and (vertex.co[0]<=self.inputs["Maximum"].default_value[0] and vertex.co[1]<=self.inputs["Maximum"].default_value[1] and vertex.co[2]<=self.inputs["Maximum"].default_value[2]))):
                     vertex.select = not self.inputs["Deselect"].default_value
-        if (bpy.context.tool_settings.mesh_select_mode[1]):
+
+        if (self.inputs["Selection Type"].default_value[1]):
             for edge in self.inputs["Object"].default_value.data.edges:
                 co = (self.inputs["Object"].default_value.data.vertices[edge.vertices[0]].co + self.inputs["Object"].default_value.data.vertices[edge.vertices[1]].co)/2
                 if (((co[0]>=self.inputs["Minimum"].default_value[0] and co[1]>=self.inputs["Minimum"].default_value[1] and co[2]>=self.inputs["Minimum"].default_value[2]) and (co[0]<=self.inputs["Maximum"].default_value[0] and co[1]<=self.inputs["Maximum"].default_value[1] and co[2]<=self.inputs["Maximum"].default_value[2]))):
                     edge.select = not self.inputs["Deselect"].default_value
-        if (bpy.context.tool_settings.mesh_select_mode[2]):
+
+        if (self.inputs["Selection Type"].default_value[2]):
             for face in self.inputs["Object"].default_value.data.polygons:
                 if (((face.center[0]>=self.inputs["Minimum"].default_value[0] and face.center[1]>=self.inputs["Minimum"].default_value[1] and face.center[2]>=self.inputs["Minimum"].default_value[2]) and (face.center[0]<=self.inputs["Maximum"].default_value[0] and face.center[1]<=self.inputs["Maximum"].default_value[1] and face.center[2]<=self.inputs["Maximum"].default_value[2]))):
                     face.select = not self.inputs["Deselect"].default_value
+
         bpy.ops.object.mode_set(mode="EDIT")

--- a/nodes/selection/ScSelectByNormal.py
+++ b/nodes/selection/ScSelectByNormal.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty
+from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty, BoolVectorProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_selection import ScSelectionNode
@@ -13,7 +13,8 @@ class ScSelectByNormal(Node, ScSelectionNode):
     in_max: FloatVectorProperty(default=(1.0, 1.0, 1.0), min=-1.0, max=1.0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    
+    selection_type: BoolVectorProperty(subtype="NONE", default=(True, False, False), update=ScNode.update_value)
+
     def init(self, context):
         super().init(context)
         self.inputs.new("ScNodeSocketVector", "Minimum").init("in_min", True)
@@ -32,20 +33,24 @@ class ScSelectByNormal(Node, ScSelectionNode):
     
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
+
+        bpy.context.tool_settings.mesh_select_mode = self.inputs["Selection Type"].default_value
+
         if (not (self.inputs["Deselect"].default_value or self.inputs["Extend"].default_value)):
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_all(action="DESELECT")
             bpy.ops.object.mode_set(mode="OBJECT")
-        if (bpy.context.tool_settings.mesh_select_mode[0]):
+
+        if (self.inputs["Selection Type"].default_value[0]):
             for vertex in self.inputs["Object"].default_value.data.vertices:
                 if (((vertex.normal[0]>=self.inputs["Minimum"].default_value[0] and vertex.normal[1]>=self.inputs["Minimum"].default_value[1] and vertex.normal[2]>=self.inputs["Minimum"].default_value[2]) and (vertex.normal[0]<=self.inputs["Maximum"].default_value[0] and vertex.normal[1]<=self.inputs["Maximum"].default_value[1] and vertex.normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     vertex.select = not self.inputs["Deselect"].default_value
-        if (bpy.context.tool_settings.mesh_select_mode[1]):
+        if (self.inputs["Selection Type"].default_value[1]):
             for edge in self.inputs["Object"].default_value.data.edges:
                 normal = (self.inputs["Object"].default_value.data.vertices[edge.vertices[0]].normal + self.inputs["Object"].default_value.data.vertices[edge.vertices[1]].normal)/2
                 if (((normal[0]>=self.inputs["Minimum"].default_value[0] and normal[1]>=self.inputs["Minimum"].default_value[1] and normal[2]>=self.inputs["Minimum"].default_value[2]) and (normal[0]<=self.inputs["Maximum"].default_value[0] and normal[1]<=self.inputs["Maximum"].default_value[1] and normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     edge.select = not self.inputs["Deselect"].default_value
-        if (bpy.context.tool_settings.mesh_select_mode[2]):
+        if (self.inputs["Selection Type"].default_value[2]):
             for face in self.inputs["Object"].default_value.data.polygons:
                 if (((face.normal[0]>=self.inputs["Minimum"].default_value[0] and face.normal[1]>=self.inputs["Minimum"].default_value[1] and face.normal[2]>=self.inputs["Minimum"].default_value[2]) and (face.normal[0]<=self.inputs["Maximum"].default_value[0] and face.normal[1]<=self.inputs["Maximum"].default_value[1] and face.normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     face.select = not self.inputs["Deselect"].default_value

--- a/nodes/selection/ScSelectByNormal.py
+++ b/nodes/selection/ScSelectByNormal.py
@@ -13,11 +13,9 @@ class ScSelectByNormal(Node, ScSelectionNode):
     in_max: FloatVectorProperty(default=(1.0, 1.0, 1.0), min=-1.0, max=1.0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
     
     def init(self, context):
         super().init(context)
-        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.inputs.new("ScNodeSocketVector", "Minimum").init("in_min", True)
         self.inputs.new("ScNodeSocketVector", "Maximum").init("in_max", True)
         self.inputs.new("ScNodeSocketBool", "Extend").init("in_extend")
@@ -38,8 +36,6 @@ class ScSelectByNormal(Node, ScSelectionNode):
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_all(action="DESELECT")
             bpy.ops.object.mode_set(mode="OBJECT")
-
-        bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
 
         if (bpy.context.tool_settings.mesh_select_mode[0]):
             for vertex in self.inputs["Object"].default_value.data.vertices:

--- a/nodes/selection/ScSelectByNormal.py
+++ b/nodes/selection/ScSelectByNormal.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty, BoolVectorProperty
+from bpy.props import EnumProperty, FloatVectorProperty, BoolProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_selection import ScSelectionNode
@@ -13,10 +13,11 @@ class ScSelectByNormal(Node, ScSelectionNode):
     in_max: FloatVectorProperty(default=(1.0, 1.0, 1.0), min=-1.0, max=1.0, update=ScNode.update_value)
     in_extend: BoolProperty(update=ScNode.update_value)
     in_deselect: BoolProperty(update=ScNode.update_value)
-    selection_type: BoolVectorProperty(subtype="NONE", default=(True, False, False), update=ScNode.update_value)
-
+    in_selection_type: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
+    
     def init(self, context):
         super().init(context)
+        self.inputs.new("ScNodeSocketSelectionType", "Selection Type").init("in_selection_type", True)
         self.inputs.new("ScNodeSocketVector", "Minimum").init("in_min", True)
         self.inputs.new("ScNodeSocketVector", "Maximum").init("in_max", True)
         self.inputs.new("ScNodeSocketBool", "Extend").init("in_extend")
@@ -33,24 +34,23 @@ class ScSelectByNormal(Node, ScSelectionNode):
     
     def functionality(self):
         bpy.ops.object.mode_set(mode="OBJECT")
-
-        bpy.context.tool_settings.mesh_select_mode = self.inputs["Selection Type"].default_value
-
         if (not (self.inputs["Deselect"].default_value or self.inputs["Extend"].default_value)):
             bpy.ops.object.mode_set(mode="EDIT")
             bpy.ops.mesh.select_all(action="DESELECT")
             bpy.ops.object.mode_set(mode="OBJECT")
 
-        if (self.inputs["Selection Type"].default_value[0]):
+        bpy.context.tool_settings.mesh_select_mode = ["VERT" in self.inputs["Selection Type"].default_value, "EDGE" in self.inputs["Selection Type"].default_value, "FACE" in self.inputs["Selection Type"].default_value]
+
+        if (bpy.context.tool_settings.mesh_select_mode[0]):
             for vertex in self.inputs["Object"].default_value.data.vertices:
                 if (((vertex.normal[0]>=self.inputs["Minimum"].default_value[0] and vertex.normal[1]>=self.inputs["Minimum"].default_value[1] and vertex.normal[2]>=self.inputs["Minimum"].default_value[2]) and (vertex.normal[0]<=self.inputs["Maximum"].default_value[0] and vertex.normal[1]<=self.inputs["Maximum"].default_value[1] and vertex.normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     vertex.select = not self.inputs["Deselect"].default_value
-        if (self.inputs["Selection Type"].default_value[1]):
+        if (bpy.context.tool_settings.mesh_select_mode[1]):
             for edge in self.inputs["Object"].default_value.data.edges:
                 normal = (self.inputs["Object"].default_value.data.vertices[edge.vertices[0]].normal + self.inputs["Object"].default_value.data.vertices[edge.vertices[1]].normal)/2
                 if (((normal[0]>=self.inputs["Minimum"].default_value[0] and normal[1]>=self.inputs["Minimum"].default_value[1] and normal[2]>=self.inputs["Minimum"].default_value[2]) and (normal[0]<=self.inputs["Maximum"].default_value[0] and normal[1]<=self.inputs["Maximum"].default_value[1] and normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     edge.select = not self.inputs["Deselect"].default_value
-        if (self.inputs["Selection Type"].default_value[2]):
+        if (bpy.context.tool_settings.mesh_select_mode[2]):
             for face in self.inputs["Object"].default_value.data.polygons:
                 if (((face.normal[0]>=self.inputs["Minimum"].default_value[0] and face.normal[1]>=self.inputs["Minimum"].default_value[1] and face.normal[2]>=self.inputs["Minimum"].default_value[2]) and (face.normal[0]<=self.inputs["Maximum"].default_value[0] and face.normal[1]<=self.inputs["Maximum"].default_value[1] and face.normal[2]<=self.inputs["Maximum"].default_value[2]))):
                     face.select = not self.inputs["Deselect"].default_value

--- a/nodes/settings/ScEditMode.py
+++ b/nodes/settings/ScEditMode.py
@@ -9,7 +9,7 @@ class ScEditMode(Node, ScNode):
     bl_idname = "ScEditMode"
     bl_label = "Edit Mode"
 
-    prop_mode: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", 2), ("EDGE", "Edges", "", 4), ("FACE", "Faces", "", 8)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
+    prop_mode: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], default={"VERT", "EDGE", "FACE"}, options={"ENUM_FLAG"}, update=ScNode.update_value)
 
     def init(self, context):
         self.node_executable = False

--- a/sockets/ScNodeSocketSelectionType.py
+++ b/sockets/ScNodeSocketSelectionType.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import FloatVectorProperty, StringProperty, BoolVectorProperty
+from bpy.props import FloatVectorProperty, StringProperty, BoolVectorProperty, EnumProperty
 from bpy.types import NodeSocket
 from ._base.socket_base import ScNodeSocket
 from ..helper import selection_type_to_string
@@ -10,7 +10,7 @@ class ScNodeSocketSelectionType(NodeSocket, ScNodeSocket):
     bl_label = "Selection Type"
     color = (0.3, 0.6, 0.9, 1.0)
 
-    default_value: BoolVectorProperty(default=(True, False, False))
+    default_value: EnumProperty(name="Mode", items=[("VERT", "Vertices", "", "VERTEXSEL", 1), ("EDGE", "Edges", "", "EDGESEL", 2), ("FACE", "Faces", "", "FACESEL", 4)], options={"ENUM_FLAG"})
     default_type: StringProperty(default="SELECTION_TYPE")
 
     def get_label(self):

--- a/sockets/ScNodeSocketSelectionType.py
+++ b/sockets/ScNodeSocketSelectionType.py
@@ -1,0 +1,17 @@
+import bpy
+
+from bpy.props import FloatVectorProperty, StringProperty, BoolVectorProperty
+from bpy.types import NodeSocket
+from ._base.socket_base import ScNodeSocket
+from ..helper import selection_type_to_string
+
+class ScNodeSocketSelectionType(NodeSocket, ScNodeSocket):
+    bl_idname = "ScNodeSocketSelectionType"
+    bl_label = "Selection Type"
+    color = (0.3, 0.6, 0.9, 1.0)
+
+    default_value: BoolVectorProperty(default=(True, False, False))
+    default_type: StringProperty(default="SELECTION_TYPE")
+
+    def get_label(self):
+        return selection_type_to_string(self.default_value)

--- a/sockets/_base/socket_base.py
+++ b/sockets/_base/socket_base.py
@@ -45,7 +45,14 @@ class ScNodeSocket:
                     layout.label(text=text)
                 else:
                     layout.prop(self, "hide", icon='RADIOBUT_OFF', icon_only=True, invert_checkbox=True)
-                    layout.column().prop(node, self.default_prop, text=text)
+                    if self.default_prop == "in_selection_type":
+                        row = layout.row(align = True)
+                        row.label(text=text)
+                        row.prop(node, self.default_prop, index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
+                        row.prop(node, self.default_prop, index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
+                        row.prop(node, self.default_prop, index = 2, toggle = True, icon_only = True, icon = "FACESEL")
+                    else:
+                        layout.column().prop(node, self.default_prop, text=text)
     
     def execute(self, forced):
         # Execute node socket to get/set default_value

--- a/sockets/_base/socket_base.py
+++ b/sockets/_base/socket_base.py
@@ -45,7 +45,7 @@ class ScNodeSocket:
                     layout.label(text=text)
                 else:
                     layout.prop(self, "hide", icon='RADIOBUT_OFF', icon_only=True, invert_checkbox=True)
-                    if self.default_prop == "in_selection_type":
+                    if self.default_type == "SELECTION_TYPE":
                         row = layout.row(align = True)
                         row.label(text=text)
                         row.prop(node, self.default_prop, icon_only = True)

--- a/sockets/_base/socket_base.py
+++ b/sockets/_base/socket_base.py
@@ -48,9 +48,7 @@ class ScNodeSocket:
                     if self.default_prop == "in_selection_type":
                         row = layout.row(align = True)
                         row.label(text=text)
-                        row.prop(node, self.default_prop, index = 0, toggle = True, icon_only = True, icon = "VERTEXSEL")
-                        row.prop(node, self.default_prop, index = 1, toggle = True, icon_only = True, icon = "EDGESEL")
-                        row.prop(node, self.default_prop, index = 2, toggle = True, icon_only = True, icon = "FACESEL")
+                        row.prop(node, self.default_prop, icon_only = True)
                     else:
                         layout.column().prop(node, self.default_prop, text=text)
     


### PR DESCRIPTION
Closes #79 

Adds a new type: SelectionType

By default selection nodes have no selection type specified, and use the current behavior of using the edit mode selection type. 

However it is now possible to manually override the selection mode directly on the node, or plug in something to the selection type socket.

Also added icons to the EditMode node.

PS: I can also add the socket to the EditMode node as well, instead of it being just buttons. But this might break current node setups?