### PR TITLE
Improve Parent node and add Clear Parent, Get Parent, Get Children node.

### DIFF
--- a/nodes/object_operators/ScClearParent.py
+++ b/nodes/object_operators/ScClearParent.py
@@ -13,7 +13,7 @@ class ScClearParent(Node, ScObjectOperatorNode):
 
     def init(self, context):
         super().init(context)
-        self.inputs.new("ScNodeSocketString", "Type").init("ops_type")
+        self.inputs.new("ScNodeSocketString", "Type").init("ops_type", True)
 
     def error_condition(self):
         return (

--- a/nodes/object_operators/ScClearParent.py
+++ b/nodes/object_operators/ScClearParent.py
@@ -1,0 +1,27 @@
+import bpy
+
+from bpy.props import EnumProperty
+from bpy.types import Node
+from .._base.node_base import ScNode
+from .._base.node_operator import ScObjectOperatorNode
+
+class ScClearParent(Node, ScObjectOperatorNode):
+    bl_idname = "ScClearParent"
+    bl_label = "Clear Parent"
+
+    ops_type: EnumProperty(items=[('CLEAR', 'Normal', ''), ('CLEAR_KEEP_TRANSFORM', 'Keep Transform', ''), ('CLEAR_INVERSE', 'Clear Inverse', '')], default='CLEAR', update=ScNode.update_value)
+
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("ScNodeSocketString", "Type").init("ops_type")
+
+    def error_condition(self):
+        return (
+            super().error_condition()
+            or (not self.inputs["Type"].default_value in ['CLEAR', 'CLEAR_KEEP_TRANSFORM', 'CLEAR_INVERSE'])
+        )
+
+    def functionality(self):
+        bpy.ops.object.parent_clear(
+            type = self.inputs["Type"].default_value
+        )

--- a/nodes/object_operators/ScGetChildren.py
+++ b/nodes/object_operators/ScGetChildren.py
@@ -1,0 +1,27 @@
+import bpy
+
+from bpy.types import Node
+from .._base.node_base import ScNode
+from ...helper import focus_on_object
+
+class ScGetChildren(Node, ScNode):
+    bl_idname = "ScGetChildren"
+    bl_label = "Get Children"
+    
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("ScNodeSocketObject", "Object")
+        self.outputs.new("ScNodeSocketArray", "Children")
+
+    def error_condition(self):
+        return (
+            self.inputs["Object"].default_value == None
+        )
+
+    def pre_execute(self):
+        focus_on_object(self.inputs["Object"].default_value)
+    
+    def post_execute(self):
+        return {
+            "Children": repr(list(self.inputs["Object"].default_value.children))
+        }

--- a/nodes/object_operators/ScGetChildren.py
+++ b/nodes/object_operators/ScGetChildren.py
@@ -17,9 +17,6 @@ class ScGetChildren(Node, ScNode):
         return (
             self.inputs["Object"].default_value == None
         )
-
-    # def pre_execute(self):
-    #     focus_on_object(self.inputs["Object"].default_value)
     
     def post_execute(self):
         return {

--- a/nodes/object_operators/ScGetChildren.py
+++ b/nodes/object_operators/ScGetChildren.py
@@ -18,8 +18,8 @@ class ScGetChildren(Node, ScNode):
             self.inputs["Object"].default_value == None
         )
 
-    def pre_execute(self):
-        focus_on_object(self.inputs["Object"].default_value)
+    # def pre_execute(self):
+    #     focus_on_object(self.inputs["Object"].default_value)
     
     def post_execute(self):
         return {

--- a/nodes/object_operators/ScGetParent.py
+++ b/nodes/object_operators/ScGetParent.py
@@ -1,0 +1,25 @@
+import bpy
+
+from bpy.types import Node
+from .._base.node_base import ScNode
+from ...helper import focus_on_object
+
+class ScGetParent(Node, ScNode):
+    bl_idname = "ScGetParent"
+    bl_label = "Get Parent"
+    
+    def init(self, context):
+        super().init(context)
+        self.inputs.new("ScNodeSocketObject", "Object")
+        self.outputs.new("ScNodeSocketObject", "Parent")
+    
+    def error_condition(self):
+        return (
+            self.inputs["Object"].default_value == None
+        )
+    
+    def pre_execute(self):
+        focus_on_object(self.inputs["Object"].default_value)
+    
+    def post_execute(self):
+        return {"Parent": self.inputs["Object"].default_value.parent}

--- a/nodes/object_operators/ScGetParent.py
+++ b/nodes/object_operators/ScGetParent.py
@@ -18,8 +18,5 @@ class ScGetParent(Node, ScNode):
             self.inputs["Object"].default_value == None
         )
     
-    # def pre_execute(self):
-    #     focus_on_object(self.inputs["Object"].default_value)
-    
     def post_execute(self):
         return {"Parent": self.inputs["Object"].default_value.parent}

--- a/nodes/object_operators/ScGetParent.py
+++ b/nodes/object_operators/ScGetParent.py
@@ -18,8 +18,8 @@ class ScGetParent(Node, ScNode):
             self.inputs["Object"].default_value == None
         )
     
-    def pre_execute(self):
-        focus_on_object(self.inputs["Object"].default_value)
+    # def pre_execute(self):
+    #     focus_on_object(self.inputs["Object"].default_value)
     
     def post_execute(self):
         return {"Parent": self.inputs["Object"].default_value.parent}

--- a/nodes/object_operators/ScParent.py
+++ b/nodes/object_operators/ScParent.py
@@ -10,15 +10,15 @@ class ScParent(Node, ScObjectOperatorNode):
     bl_label = "Parent"
 
     prop_obj: PointerProperty(type=bpy.types.Object, update=ScNode.update_value)
-    ops_type: EnumProperty(items=[('OBJECT', 'Object', ''), ('WITHOUT_INVERSE', 'Object(Without Inverse)', '')], default='OBJECT', update=ScNode.update_value)
-    keep_transform: BoolProperty(update=ScNode.update_value)
+    in_ops_type: EnumProperty(items=[('OBJECT', 'Object', ''), ('WITHOUT_INVERSE', 'Object(Without Inverse)', '')], default='OBJECT', update=ScNode.update_value)
+    in_keep_transform: BoolProperty(update=ScNode.update_value)
 
     def init(self, context):
         super().init(context)
         self.inputs.new("ScNodeSocketObject", "Parent").init("prop_obj", True)
-        self.inputs.new("ScNodeSocketString", "Type").init("ops_type")
+        self.inputs.new("ScNodeSocketString", "Type").init("in_ops_type")
         self.inputs.new("ScNodeSocketBool", "Keep Transform").init(
-            "keep_transform")
+            "in_keep_transform")
 
     def error_condition(self):
         return (
@@ -36,6 +36,6 @@ class ScParent(Node, ScObjectOperatorNode):
             bpy.ops.object.parent_no_inverse_set()
         else:
             bpy.ops.object.parent_set(
-                type=self.inputs["Type"].default_value,
-                keep_transform=self.inputs["Keep Transform"].default_value
+                type = 'OBJECT',
+                keep_transform = self.inputs["Keep Transform"].default_value
             )

--- a/nodes/object_operators/ScParent.py
+++ b/nodes/object_operators/ScParent.py
@@ -1,6 +1,6 @@
 import bpy
 
-from bpy.props import PointerProperty
+from bpy.props import PointerProperty, EnumProperty, BoolProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 from .._base.node_operator import ScObjectOperatorNode
@@ -10,10 +10,32 @@ class ScParent(Node, ScObjectOperatorNode):
     bl_label = "Parent"
 
     prop_obj: PointerProperty(type=bpy.types.Object, update=ScNode.update_value)
+    ops_type: EnumProperty(items=[('OBJECT', 'Object', ''), ('WITHOUT_INVERSE', 'Object(Without Inverse)', '')], default='OBJECT', update=ScNode.update_value)
+    keep_transform: BoolProperty(update=ScNode.update_value)
 
     def init(self, context):
         super().init(context)
-        self.inputs.new("ScNodeSocketObject", "Parent Object").init("prop_obj", True)
-    
+        self.inputs.new("ScNodeSocketObject", "Parent").init("prop_obj", True)
+        self.inputs.new("ScNodeSocketString", "Type").init("ops_type")
+        self.inputs.new("ScNodeSocketBool", "Keep Transform").init(
+            "keep_transform")
+
+    def error_condition(self):
+        return (
+            super().error_condition()
+            or self.inputs["Parent"].default_value == None
+            or (not self.inputs["Type"].default_value in ['OBJECT', 'WITHOUT_INVERSE'])
+        )
+
     def functionality(self):
-        self.inputs["Object"].default_value.parent = self.inputs["Parent Object"].default_value
+        parent = self.inputs["Parent"].default_value
+        parent.select_set(state=True)
+        bpy.context.view_layer.objects.active = parent
+
+        if self.inputs["Type"].default_value == "WITHOUT_INVERSE":
+            bpy.ops.object.parent_no_inverse_set()
+        else:
+            bpy.ops.object.parent_set(
+                type=self.inputs["Type"].default_value,
+                keep_transform=self.inputs["Keep Transform"].default_value
+            )


### PR DESCRIPTION
1. "Parent" node now considers [parent inverse](https://docs.blender.org/manual/en/latest/scene_layout/object/properties/relations/parents.html#parent-inverse) by default. Select "Object(Without Inverse)" type if you want to return to v3.1.4 behavior.
2. Added "Clear Parent", "Get Parent", and "Get Children" node.