### PR TITLE
Add some operations to the Math node.

### DIFF
--- a/nodes/utilities/ScMathsOp.py
+++ b/nodes/utilities/ScMathsOp.py
@@ -5,13 +5,36 @@ from bpy.props import EnumProperty, FloatProperty
 from bpy.types import Node
 from .._base.node_base import ScNode
 
+op_items = [
+    # (identifier, name, description)
+    ("ADD", "X + Y", "Addition"),
+    ("SUB", "X - Y", "Subtraction"),
+    ("MULT", "X * Y", "Multiplication"),
+    ("DIV", "X / Y", "Division"),
+    None,
+    ("POW", "X ^ Y", "Exponent (Power)"),
+    ("LOG", "Log(X) to base Y", "Logarithm"),
+    ("SQRT", "√X", "Square Root"),
+    ("FACT", "!X", "X Factorial"),
+    ("ABS", "|X|", "Absolute"),
+    None,
+    ("MIN", "Min(X, Y)", "Minimum"),
+    ("MAX", "Max(X, Y)", "Maximum"),
+    None,
+    ("ROUND", "Round(X)", "Round"),
+    ("FLOOR", "Floor(X)", "Floor of X"),
+    ("CEIL", "Ceil(X)", "Ceiling of X"),
+    ("FRACT", "Fraction", "Fractional Part of X"),
+    ("MOD", "X % Y", "Modulo (Remainder)"),
+]
+
 class ScMathsOp(Node, ScNode):
     bl_idname = "ScMathsOp"
     bl_label = "Maths Operation"
 
     in_x: FloatProperty(update=ScNode.update_value)
     in_y: FloatProperty(update=ScNode.update_value)
-    in_op: EnumProperty(name="Operation", items=[("ADD", "X + Y", "Addition"), ("SUB", "X - Y", "Subtraction"), ("MULT", "X * Y", "Multiplication"), ("DIV", "X / Y", "Division"), ("MOD", "X % Y", "Modulo (Remainder)"), ("POW", "X ^ Y", "Exponent (Power)"), ("LOG", "Log(X) to base Y", "Logarithm"), ("FACT", "!X", "X Factorial")], default="ADD", update=ScNode.update_value)
+    in_op: EnumProperty(name="Operation", items=op_items, default="ADD", update=ScNode.update_value)
 
     def init(self, context):
         super().init(context)
@@ -21,30 +44,50 @@ class ScMathsOp(Node, ScNode):
         self.outputs.new("ScNodeSocketNumber", "Value")
     
     def error_condition(self):
+        op = self.inputs["Operation"].default_value
         return (
-            (not self.inputs["Operation"].default_value in ["ADD", "SUB", "MULT", "DIV", "MOD", "POW", "LOG", "FACT"])
-            or (self.inputs["Operation"].default_value in ['DIV', 'MOD'] and self.inputs["Y"].default_value == 0)
-            or (self.inputs["Operation"].default_value == "POW" and self.inputs["X"].default_value == 0 and self.inputs["Y"].default_value == 0)
-            or (self.inputs["Operation"].default_value == "LOG" and (self.inputs["X"].default_value <= 0 or self.inputs["Y"].default_value < 0 or self.inputs["Y"].default_value == 1))
-            or (self.inputs["Operation"].default_value == "FACT" and int(self.inputs["X"].default_value) < 0)
+            (not op in [i[0] for i in op_items if i])
+            or (op in ['DIV', 'MOD'] and self.inputs["Y"].default_value == 0)
+            or (op == "POW" and self.inputs["X"].default_value == 0 and self.inputs["Y"].default_value == 0)
+            or (op == "LOG" and (self.inputs["X"].default_value <= 0 or self.inputs["Y"].default_value < 0 or self.inputs["Y"].default_value == 1))
+            or (op == "FACT" and int(self.inputs["X"].default_value) < 0)
         )
 
     def post_execute(self):
         out = {}
-        if (self.inputs["Operation"].default_value == 'ADD'):
-            out["Value"] = self.inputs["X"].default_value + self.inputs["Y"].default_value
-        elif (self.inputs["Operation"].default_value == 'SUB'):
-            out["Value"] = self.inputs["X"].default_value - self.inputs["Y"].default_value
-        elif (self.inputs["Operation"].default_value == 'MULT'):
-            out["Value"] = self.inputs["X"].default_value * self.inputs["Y"].default_value
-        elif (self.inputs["Operation"].default_value == 'DIV'):
-            out["Value"] = self.inputs["X"].default_value / self.inputs["Y"].default_value
-        elif (self.inputs["Operation"].default_value == 'MOD'):
-            out["Value"] = int(self.inputs["X"].default_value) % int(self.inputs["Y"].default_value)
-        elif (self.inputs["Operation"].default_value == 'POW'):
-            out["Value"] = pow(self.inputs["X"].default_value, self.inputs["Y"].default_value)
-        elif (self.inputs["Operation"].default_value == 'LOG'):
-            out["Value"] = math.log(self.inputs["X"].default_value, self.inputs["Y"].default_value)
-        elif (self.inputs["Operation"].default_value == 'FACT'):
-            out["Value"] = math.factorial(int(self.inputs["X"].default_value))
+        op = self.inputs["Operation"].default_value
+        x = self.inputs["X"].default_value
+        y = self.inputs["Y"].default_value
+        if (op == 'ADD'):
+            out["Value"] = x + y
+        elif (op == 'SUB'):
+            out["Value"] = x - y
+        elif (op == 'MULT'):
+            out["Value"] = x * y
+        elif (op == 'DIV'):
+            out["Value"] = x / y
+        elif (op == 'POW'):
+            out["Value"] = pow(x, y)
+        elif (op == 'LOG'):
+            out["Value"] = math.log(x, y)
+        elif (op == 'SQRT'):
+            out["Value"] = math.sqrt(x)
+        elif (op == 'FACT'):
+            out["Value"] = math.factorial(int(x))
+        elif (op == 'ABS'):
+            out["Value"] = abs(x)
+        elif (op == 'MIN'):
+            out["Value"] = min(x, y)
+        elif (op == 'MAX'):
+            out["Value"] = max(x, y)
+        elif (op == 'ROUND'):
+            out["Value"] = round(x)
+        elif (op == 'FLOOR'):
+            out["Value"] = math.floor(x)
+        elif (op == 'CEIL'):
+            out["Value"] = math.ceil(x)
+        elif (op == 'FRACT'):
+            out["Value"] = x - math.floor(x)
+        elif (op == 'MOD'):
+            out["Value"] = int(x) % int(y)
         return out

--- a/nodes/utilities/ScMathsOp.py
+++ b/nodes/utilities/ScMathsOp.py
@@ -89,5 +89,5 @@ class ScMathsOp(Node, ScNode):
         elif (op == 'FRACT'):
             out["Value"] = x - math.floor(x)
         elif (op == 'MOD'):
-            out["Value"] = int(x) % int(y)
+            out["Value"] = x % y
         return out


### PR DESCRIPTION
I suggest adding some missing operations to the Math node: "sqrt", "abs", "min", "max", "round", "floor", "ceil", "fraction".

These are found in the Math node of Blender Shader and Composite, but not in Sorcar. I think it would be better if Sorcar's Math node could be used as well as that of Shader. Beginners from Shader node will be able to use without hesitation.

I understand that these operations can be achieved by combining existing nodes. But they will make some node trees simpler and more straightforward.

What do you think?

<img width="232" alt="スクリーンショット 2020-02-08 0 13 26 1" src="https://user-images.githubusercontent.com/12822756/74041214-98161800-4a08-11ea-8b98-f83d6b1a9657.png">
